### PR TITLE
Made deep clone of spec object in translate().

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function translate(object, language) {
     if (typeof(object) !== 'object') {
         throw new Error('Passed swagger schema must be object. Not `' + typeof(object) + '`')
     }
-    object = Object.assign({}, object)
+    let translatedSpec = JSON.parse(JSON.stringify(object))
     validateLanguageCode(language)
     iterator(object, function (value, key, subject, path) {
         if (typeof(key) === 'string') {
@@ -48,7 +48,7 @@ function translate(object, language) {
             }
         }
     });
-    return object
+    return translatedSpec
 }
 
 function getUsedLanguageCodes(object) {


### PR DESCRIPTION
**translate-all** option on files having multiple language definitions didn't work - all output files had the translation strings of the first language.
Identified root cause as: original spec object got mutated in the translate() function. Even though Object.assign was used to create a copy of the original object, Object.assign() creates a shallow copy only. So, when the i18n property is deleted it's also deleted from the original spec and that causes every subsequent language to not be translated and inherit the first language's translation.
Solution: create a deep copy of the original spec using JSON serialization/de-serialization.
